### PR TITLE
Avoid loading eldritch gem globally

### DIFF
--- a/lib/sidekiq_queue_metrics.rb
+++ b/lib/sidekiq_queue_metrics.rb
@@ -1,7 +1,7 @@
 require 'sidekiq'
 require 'sidekiq/api'
 require "sidekiq/web"
-require 'eldritch'
+require 'eldritch/safe'
 
 project_root = File.dirname(File.absolute_path(__FILE__))
 Dir.glob(project_root + '/sidekiq_queue_metrics/**/*.rb', &method(:require))

--- a/lib/sidekiq_queue_metrics/queue_metrics.rb
+++ b/lib/sidekiq_queue_metrics/queue_metrics.rb
@@ -1,6 +1,8 @@
 require 'sidekiq_queue_metrics/storage'
 
 module Sidekiq::QueueMetrics
+  extend Eldritch::DSL
+
   class << self
     def fetch
       queues = []


### PR DESCRIPTION
Loading eldritch globally through `require 'eldritch'` may cause issues with other libraries implementing similar concurrency behaviors (specially for `async` method). This way allows sidekiq_queue_metrics to work ok without polluting other client concurrency mechanisms.

Let me know if it make sense to you. I ran into this issue, so I thought it make sense to include it here. But I could be missing another use case!

Thanks! 