### PR TITLE
Use relative URLs in Sidekiq UI links

### DIFF
--- a/lib/sidekiq_queue_metrics/views/queue_summary.erb
+++ b/lib/sidekiq_queue_metrics/views/queue_summary.erb
@@ -60,7 +60,7 @@
       <td><%= job['class'] %></td>
       <td><%= job['args'].join(', ') %></td>
       <td>
-        <a href="<%= "/sidekiq/queue_metrics/queues/#{@queue}/jobs/#{job['jid']}" %>">
+        <a href="<%= "#{root_path}queue_metrics/queues/#{@queue}/jobs/#{job['jid']}" %>">
           <%= relative_time(Time.at(job['enqueued_at'])) %>
         </a>
       </td>

--- a/lib/sidekiq_queue_metrics/views/queues_stats.erb
+++ b/lib/sidekiq_queue_metrics/views/queues_stats.erb
@@ -59,7 +59,7 @@
     <thead>
     <tr>
       <th>
-        <a href="<%= "/sidekiq/queue_metrics/queues/#{queue}/summary" %>">
+        <a href="<%= "#{root_path}queue_metrics/queues/#{queue}/summary" %>">
           <span class="heading"><%= queue %></span>
         </a>
       </th>


### PR DESCRIPTION
I have a Rails app where the Sidekiq admin web interface is configured (through `config/routes.rb`) to be accessed at a non-standard location:

```ruby
mount Sidekiq::Web => '/admin/sidekiq', as: 'sidekiq'
```

This means that a few of the links in `sidekiq_queue_metrics` don't work because they have a hard-coded base of `"/sidekiq"`. This PR replaces that with the `"#{root_url}"` helper so that such links continue to work in situations where the user has mounted the Sidekiq web interface at a custom location.