### PR TITLE
Fix #exists usage

### DIFF
--- a/lib/sidekiq_queue_metrics/upgrade_manager.rb
+++ b/lib/sidekiq_queue_metrics/upgrade_manager.rb
@@ -37,7 +37,7 @@ module Sidekiq
 
             failed_jobs_key = Helpers.build_failed_jobs_key(queue)
 
-            if conn.exists(failed_jobs_key) && conn.type(failed_jobs_key) == 'string'
+            if conn.exists?(failed_jobs_key) && conn.type(failed_jobs_key) == 'string'
               temporal_failed_key = "_#{failed_jobs_key}"
 
               failed_jobs = JSON.parse(conn.get(Helpers.build_failed_jobs_key(queue)) || '[]')
@@ -57,7 +57,7 @@ module Sidekiq
       end
 
       def self.upgrade_needed?
-        Sidekiq.redis_pool.with { |conn| conn.exists(Helpers.stats_key) }
+        Sidekiq.redis_pool.with { |conn| conn.exists?(Helpers.stats_key) }
       end
 
       def self.acquire_lock(&block)

--- a/spec/lib/sidekiq_queue_metrics/upgrade_manager_spec.rb
+++ b/spec/lib/sidekiq_queue_metrics/upgrade_manager_spec.rb
@@ -37,7 +37,7 @@ describe Sidekiq::QueueMetrics::UpgradeManager do
       it 'should delete the old stats key' do
         Sidekiq::QueueMetrics::UpgradeManager.v2_to_v3_upgrade
 
-        expect(redis_connection.exists(Sidekiq::QueueMetrics::Helpers.stats_key)).to be_falsey
+        expect(redis_connection.exists?(Sidekiq::QueueMetrics::Helpers.stats_key)).to be_falsey
       end
 
       it 'should set the previous values into the new stats format' do
@@ -66,8 +66,8 @@ describe Sidekiq::QueueMetrics::UpgradeManager do
 
         Sidekiq::QueueMetrics::UpgradeManager.v2_to_v3_upgrade
 
-        expect(redis_connection.exists(mailer_temporal_key)).to be_falsey
-        expect(redis_connection.exists(other_temporal_key)).to be_falsey
+        expect(redis_connection.exists?(mailer_temporal_key)).to be_falsey
+        expect(redis_connection.exists?(other_temporal_key)).to be_falsey
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
 
-require 'fakeredis/rspec'
-
 require './lib/sidekiq_queue_metrics'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Redis#exists method returns integer now. Redis#exists? should be used instead.